### PR TITLE
Add support for caching arrays to filesystem cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   ios:
     macos:
-      xcode: "10.1.0"
+      xcode: "10.2.0"
     steps:
       - checkout
       - run:

--- a/CacheMeIfYouCan.podspec
+++ b/CacheMeIfYouCan.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "CacheMeIfYouCan"
   s.summary          = "Swift Generic Thread Safe Caching"
-  s.version          = "0.1"
+  s.version          = "0.2"
   s.homepage         = "https://github.com/bakkenbaeck/CacheMeIfYouCan"
   s.license          = 'MIT'
   s.author           = { "Bakken & Bæck" => "ios@bakkenbaeck.com" }

--- a/CacheMeIfYouCan/CacheMeIfYouCan.xcodeproj/project.pbxproj
+++ b/CacheMeIfYouCan/CacheMeIfYouCan.xcodeproj/project.pbxproj
@@ -312,14 +312,16 @@
 				TargetAttributes = {
 					9B57952821BF00B900B9EF8B = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1020;
 					};
 					9B57953C21BF00BA00B9EF8B = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1020;
 						TestTargetID = 9B57952821BF00B900B9EF8B;
 					};
 					9B57955021BF015900B9EF8B = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
@@ -578,7 +580,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = no.bakkenbaeck.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -596,7 +598,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = no.bakkenbaeck.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -615,7 +617,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = no.bakkenbaeck.CacheMeIfYouCanTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DemoApp.app/DemoApp";
 			};
@@ -635,7 +637,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = no.bakkenbaeck.CacheMeIfYouCanTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DemoApp.app/DemoApp";
 			};
@@ -664,7 +666,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -693,7 +695,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.bakkenbaeck.CacheMeIfYouCan;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/CacheMeIfYouCan/CacheMeIfYouCan.xcodeproj/project.pbxproj
+++ b/CacheMeIfYouCan/CacheMeIfYouCan.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		9B57958B21C00DB000B9EF8B /* InMemoryCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B57958A21C00DB000B9EF8B /* InMemoryCacheTests.swift */; };
 		9B57958D21C010AA00B9EF8B /* InMemoryImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B57958C21C010AA00B9EF8B /* InMemoryImageCache.swift */; };
 		9B57958F21C010E300B9EF8B /* TestImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B57958E21C010E300B9EF8B /* TestImageLoader.swift */; };
+		9BB8B499221EB14200A3E331 /* DataConvertibleCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB8B498221EB14200A3E331 /* DataConvertibleCodableTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +100,7 @@
 		9B57958A21C00DB000B9EF8B /* InMemoryCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryCacheTests.swift; sourceTree = "<group>"; };
 		9B57958C21C010AA00B9EF8B /* InMemoryImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryImageCache.swift; sourceTree = "<group>"; };
 		9B57958E21C010E300B9EF8B /* TestImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestImageLoader.swift; sourceTree = "<group>"; };
+		9BB8B498221EB14200A3E331 /* DataConvertibleCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataConvertibleCodableTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -167,6 +169,7 @@
 				9B57958E21C010E300B9EF8B /* TestImageLoader.swift */,
 				9B57954321BF00BA00B9EF8B /* Info.plist */,
 				9B57957121BFBEEB00B9EF8B /* TestCacheTypes */,
+				9BB8B498221EB14200A3E331 /* DataConvertibleCodableTests.swift */,
 				9B57957621BFCE0900B9EF8B /* FileSystemDataCacheTests.swift */,
 				9B57958821C005D200B9EF8B /* ImageCacheTests.swift */,
 				9B57958A21C00DB000B9EF8B /* InMemoryCacheTests.swift */,
@@ -382,6 +385,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9BB8B499221EB14200A3E331 /* DataConvertibleCodableTests.swift in Sources */,
 				9B57958F21C010E300B9EF8B /* TestImageLoader.swift in Sources */,
 				9B57958D21C010AA00B9EF8B /* InMemoryImageCache.swift in Sources */,
 				9B57957321BFBEFD00B9EF8B /* UserCache.swift in Sources */,

--- a/CacheMeIfYouCan/CacheMeIfYouCan/CacheTypes/Cache.swift
+++ b/CacheMeIfYouCan/CacheMeIfYouCan/CacheTypes/Cache.swift
@@ -109,7 +109,6 @@ public extension Cache {
         }
     }                                   
     
-    
     /// Fetches an item using the local queue to ensure order of operations
     ///
     /// - Parameters:

--- a/CacheMeIfYouCan/CacheMeIfYouCan/CacheTypes/Cache.swift
+++ b/CacheMeIfYouCan/CacheMeIfYouCan/CacheTypes/Cache.swift
@@ -41,7 +41,7 @@ public protocol Cache: class {
 
 public extension Cache {
     
-    public static var defaultQueue: DispatchQueue {
+    static var defaultQueue: DispatchQueue {
         return DispatchQueue(
             label: String(describing: Self.self),
             qos: .userInitiated,
@@ -55,7 +55,7 @@ public extension Cache {
     ///   - url: The URL to store it for
     ///   - queue: The queue to fire the completion closure on. Defaults to the main queue.
     ///   - completion: [Optional] The completion closure to fire. Defaults to nil.
-    public func store(item: StoredType,
+    func store(item: StoredType,
                       for url: URL,
                       callbackOn queue: DispatchQueue = .main,
                       completion: (() -> Void)? = nil) { 
@@ -86,7 +86,7 @@ public extension Cache {
     ///   - completion: The completion closure to fire.
     ///                 Params:
     ///                 - [Optional] The stored item found at the given url, or nil.
-    public func fetchItem(for url: URL,
+    func fetchItem(for url: URL,
                           callbackOn queue: DispatchQueue = .main,
                           completion: @escaping (StoredType?) -> Void) {
         self.localQueue.async { [weak self] in
@@ -116,7 +116,7 @@ public extension Cache {
     ///   - url: The URL to remove any stored item for.
     ///   - queue: The queue to fire the completion closure on. Defaults to the main queue.
     ///   - completion: [Optional] The completion closure to fire. Defaults to nil.
-    public func removeItem(for url: URL,
+    func removeItem(for url: URL,
                            callbackOn queue: DispatchQueue = .main,
                            completion: (() -> Void)? = nil) {
         self.localQueue.async { [weak self] in

--- a/CacheMeIfYouCan/CacheMeIfYouCan/CacheTypes/FileSystemDataCache.swift
+++ b/CacheMeIfYouCan/CacheMeIfYouCan/CacheTypes/FileSystemDataCache.swift
@@ -103,6 +103,13 @@ open class FileSystemDataCache<ConvertibleStoredType: DataConvertible>: Cache {
     
     // MARK: - Array Storage/Fetching
     
+    /// Stores an item using the local queue to ensure order of operations
+    ///
+    /// - Parameters:
+    ///   - items: The array of items to store
+    ///   - url: The URL to store the array for
+    ///   - queue: The queue to fire the completion closure on. Defaults to the main queue.
+    ///   - completion: [Optional] The completion closure to fire. Defaults to nil.
     open func store(items: [ConvertibleStoredType],
                     for url: URL,
                     callbackOn queue: DispatchQueue = .main,
@@ -126,11 +133,19 @@ open class FileSystemDataCache<ConvertibleStoredType: DataConvertible>: Cache {
         }
     }
     
+    /// Fetches an array of items using the local queue to ensure order of operations
+    ///
+    /// - Parameters:
+    ///   - url: The URL to search for an array for.
+    ///   - queue: The queue to fire the completion closure on. Defaults to the main queue.
+    ///   - completion: The completion closure to fire.
+    ///                 Params:
+    ///                 - [Optional] The array of stored items found at the given url, or nil.
     open func fetchItems(for url: URL,
                          callbackOn queue: DispatchQueue = .main,
-                         completion: @escaping ([StoredType]?) -> Void) {
+                         completion: @escaping ([ConvertibleStoredType]?) -> Void) {
         self.localQueue.async { [weak self] in
-            var items: [StoredType]? = nil
+            var items: [ConvertibleStoredType]? = nil
             defer {
                 queue.async {
                     completion(items)

--- a/CacheMeIfYouCan/CacheMeIfYouCan/Protocols/DataConvertible.swift
+++ b/CacheMeIfYouCan/CacheMeIfYouCan/Protocols/DataConvertible.swift
@@ -26,7 +26,7 @@ public protocol DataConvertible {
     init?(data: Data)
 }
 
-extension Array where Element: DataConvertible {
+public extension Array where Element: DataConvertible {
     
     var toData: Data? {
         let datas = self.compactMap { $0.toData }

--- a/CacheMeIfYouCan/CacheMeIfYouCan/Protocols/DataConvertibleCodable.swift
+++ b/CacheMeIfYouCan/CacheMeIfYouCan/Protocols/DataConvertibleCodable.swift
@@ -34,3 +34,16 @@ public extension DataConvertibleCodable {
         self = decoded
     }
 }
+
+// MARK: - Arrays of codables
+
+public extension Array where Element: DataConvertibleCodable {
+    
+    var toData: Data?  {
+        return try? Element.encoder.encode(self)
+    }
+    
+    static func fromData(_ data: Data) -> [Element]? {
+        return try? Element.decoder.decode([Element].self, from: data)
+    }
+}

--- a/CacheMeIfYouCan/CacheMeIfYouCan/Protocols/DataConvertibleCodable.swift
+++ b/CacheMeIfYouCan/CacheMeIfYouCan/Protocols/DataConvertibleCodable.swift
@@ -32,7 +32,7 @@ public extension DataConvertibleCodable {
         }
         
         self = decoded
-    }
+    }    
 }
 
 // MARK: - Arrays of codables

--- a/CacheMeIfYouCan/CacheMeIfYouCanTests/DataConvertibleCodableTests.swift
+++ b/CacheMeIfYouCan/CacheMeIfYouCanTests/DataConvertibleCodableTests.swift
@@ -1,0 +1,76 @@
+//
+//  DataConvertibleCodableTests.swift
+//  CacheMeIfYouCanTests
+//
+//  Created by Ellen Shapiro on 2/21/19.
+//  Copyright © 2019 Bakken & Baeck. All rights reserved.
+//
+
+import CacheMeIfYouCan
+import XCTest
+
+class DataConvertibleCodableTests: XCTestCase {
+    
+    private let userArray = [
+        User(name: "Homer",
+             email: "homer@snpp.com",
+             isAdmin: false),
+        User(name: "Smithers",
+             email: "smithers@snpp.com",
+             isAdmin: true),
+        User(name: "BumblebeeMan",
+             email: "bbm@channelocho.tv",
+             isAdmin: false)
+    ]
+    
+    private let jsonArray = """
+[
+    {
+        "name": "Homer",
+        "email": "homer@snpp.com",
+        "isAdmin": false
+    },
+    {
+        "name": "Smithers",
+        "email": "smithers@snpp.com",
+        "isAdmin": true
+    },
+    {
+        "name": "BumblebeeMan",
+        "email": "bbm@channelocho.tv",
+        "isAdmin": false
+    }
+]
+"""
+
+    func testEncodingArrayOfUsers() {
+        guard let data = self.userArray.toData else {
+            XCTFail("No data from array of users")
+            return
+        }
+        
+        let noSpacesArray = self.jsonArray
+            .replacingOccurrences(of: "\n", with: "")
+            .replacingOccurrences(of: "\t", with: "")
+            .replacingOccurrences(of: " ", with: "")
+        
+        let string = String(data: data, encoding: .utf8)
+        XCTAssertEqual(string, noSpacesArray)
+    }
+    
+    func testDecodingArrayOfUsers() {
+        guard let data = self.jsonArray.data(using: .utf8) else {
+            XCTFail("Could not create data from json string")
+            return
+        }
+        
+        guard let users = [User].fromData(data) else {
+            XCTFail("Could not decode users from data!")
+            return
+        }
+        
+        XCTAssertEqual(users, self.userArray)
+    }
+    
+}
+

--- a/CacheMeIfYouCan/CacheMeIfYouCanTests/DataConvertibleCodableTests.swift
+++ b/CacheMeIfYouCan/CacheMeIfYouCanTests/DataConvertibleCodableTests.swift
@@ -71,6 +71,5 @@ class DataConvertibleCodableTests: XCTestCase {
         
         XCTAssertEqual(users, self.userArray)
     }
-    
 }
 

--- a/CacheMeIfYouCan/CacheMeIfYouCanTests/FileSystemDataCacheTests.swift
+++ b/CacheMeIfYouCan/CacheMeIfYouCanTests/FileSystemDataCacheTests.swift
@@ -11,6 +11,8 @@ import CacheMeIfYouCan
 
 class FileSystemDataCacheTests: XCTestCase {
     
+    let allUsersURL = URL(string: "https://www.url.com/user/all")!
+
     let user1URL = URL(string: "https://www.url.com/user/1")!
     let user2URL = URL(string: "https://www.url.com/user/2")!
     let user3URL = URL(string: "https://www.url.com/user/3")!
@@ -58,6 +60,23 @@ class FileSystemDataCacheTests: XCTestCase {
         self.wait(for: [userStoreExpectation], timeout: 1)
     }
     
+    private func storeUserArray(_ users: [User],
+                                for url: URL,
+                                in cache: UserCache,
+                                file: StaticString = #file,
+                                line: UInt = #line) {
+        let arrayStoreExpectation = self.expectation(description: "User array store expectation")
+        cache.store(items: users, for: url) {
+            XCTAssertTrue(Thread.isMainThread,
+                          "Callback should be on the main thread by default",
+                          file: file,
+                          line: line)
+            arrayStoreExpectation.fulfill()
+        }
+        
+        self.wait(for: [arrayStoreExpectation], timeout: 1)
+    }
+    
     private func fetchUser(for url: URL,
                            from cache: UserCache,
                            file: StaticString = #file,
@@ -79,10 +98,30 @@ class FileSystemDataCacheTests: XCTestCase {
         return retrievedUser
     }
     
-    private func removeUser(for url: URL,
-                            from cache: UserCache,
-                            file: StaticString = #file,
-                            line: UInt = #line) {
+    private func fetchUserArray(for url: URL,
+                                from cache: UserCache,
+                                file: StaticString = #file,
+                                line: UInt = #line) -> [User]? {
+        let userArrayRetrieveExpectation = self.expectation(description: "User array retrieved expectation")
+        
+        var retrievedUsers: [User]? = nil
+        cache.fetchItems(for: url) { users in
+            XCTAssertTrue(Thread.isMainThread,
+                          "Callback should be on main thread by default",
+                          file: file,
+                          line: line)
+            retrievedUsers = users
+            userArrayRetrieveExpectation.fulfill()
+        }
+        
+        self.wait(for: [userArrayRetrieveExpectation], timeout: 1)
+        return retrievedUsers
+    }
+    
+    private func removeUserOrUsers(for url: URL,
+                                   from cache: UserCache,
+                                   file: StaticString = #file,
+                                   line: UInt = #line) {
         let userRemoveExpectation = self.expectation(description: "User remove expectation")
         
         cache.removeItem(for: url) {
@@ -97,9 +136,7 @@ class FileSystemDataCacheTests: XCTestCase {
     }
     
     private func validateStoring(with cache: UserCache,
-                                 expectedDirectoryURL directoryURL: URL,
-                                 file: StaticString = #file,
-                                 line: UInt = #line) throws {
+                                 expectedDirectoryURL directoryURL: URL) throws {
         // Does creating the cache make sure its underlying directory exists?
         XCTAssertTrue(FileManagerHelper.directoryExists(at: directoryURL))
         XCTAssertEqual(try FileManagerHelper.contentsOfDirectory(at: directoryURL).count, 0)
@@ -142,7 +179,7 @@ class FileSystemDataCacheTests: XCTestCase {
         XCTAssertEqual(fetchedUser3, self.user3)
         
         // Remove an item and make sure it's gone 
-        self.removeUser(for: self.user3URL, from: cache)
+        self.removeUserOrUsers(for: self.user3URL, from: cache)
         
         XCTAssertNil(self.fetchUser(for: self.user3URL, from: cache))
         XCTAssertFalse(FileManagerHelper.fileExists(at: user3ExpectedPath))
@@ -157,6 +194,39 @@ class FileSystemDataCacheTests: XCTestCase {
         XCTAssertFalse(FileManagerHelper.fileExists(at: user1ExpectedPath))
         XCTAssertFalse(FileManagerHelper.fileExists(at: user2ExpectedPath))
         XCTAssertFalse(FileManagerHelper.fileExists(at: user3ExpectedPath))
+        
+        // As should anything else in there
+        XCTAssertEqual(try FileManagerHelper.contentsOfDirectory(at: directoryURL).count, 0)
+    }
+    
+    private func validateStoringArray(cache: UserCache,
+                                      expectedDirectoryURL directoryURL: URL) throws {
+        let array = [
+            self.user1,
+            self.user2,
+            self.user3
+        ]
+        
+        self.storeUserArray(array, for: self.allUsersURL, in: cache)
+        
+        guard let fromStorage = self.fetchUserArray(for: self.allUsersURL, from: cache) else {
+            XCTFail("Could not fetch array from storage!")
+            return
+        }
+        
+        XCTAssertEqual(fromStorage, array)
+        
+        let allUsersExpectedPath = FileSystemPathHelper.path(byAppending: "all", to: directoryURL.path)
+        XCTAssertTrue(FileManagerHelper.fileExists(at: allUsersExpectedPath))
+        
+        // Get rid of EVERYTHING
+        try cache.clearAll()
+        
+        // The directory should still exist
+        XCTAssertTrue(FileManagerHelper.directoryExists(at: directoryURL))
+        
+        // But the stored array should be removed
+        XCTAssertFalse(FileManagerHelper.fileExists(at: allUsersExpectedPath))
         
         // As should anything else in there
         XCTAssertEqual(try FileManagerHelper.contentsOfDirectory(at: directoryURL).count, 0)
@@ -180,6 +250,35 @@ class FileSystemDataCacheTests: XCTestCase {
         }
         
         XCTAssertEqual(user2, self.user2)
+    }
+    
+    
+    private func validateReplacingArray(cache: UserCache) {
+        let array = [
+            self.user1,
+            self.user2,
+            self.user3
+        ]
+        
+        self.storeUserArray(array, for: self.allUsersURL, in: cache)
+        guard let fromStorage = self.fetchUserArray(for: self.allUsersURL, from: cache) else {
+            XCTFail("Could not fetch array from storage!")
+            return
+        }
+        
+        XCTAssertEqual(fromStorage, array)
+        
+        let array2 = [
+            self.user2
+        ]
+        
+        self.storeUserArray(array2, for: self.allUsersURL, in: cache)
+        guard let fromStorage2 = self.fetchUserArray(for: self.allUsersURL, from: cache) else {
+            XCTFail("Could not refetch array from storage after replacing it!")
+            return
+        }
+        
+        XCTAssertEqual(fromStorage2, array2)
     }
     
     // MARK: - Tests
@@ -217,6 +316,7 @@ class FileSystemDataCacheTests: XCTestCase {
         let cache = UserCache(rootDirectory: .caches, subdirectoryName: "users")
         
         try self.validateStoring(with: cache, expectedDirectoryURL: url)
+        try self.validateStoringArray(cache: cache, expectedDirectoryURL: url)
     }
     
     func testStoringInDocumentsDirectory() throws {
@@ -231,16 +331,19 @@ class FileSystemDataCacheTests: XCTestCase {
         let cache = UserCache(rootDirectory: .documents, subdirectoryName: "users")
         
         try self.validateStoring(with: cache, expectedDirectoryURL: url)
+        try self.validateStoringArray(cache: cache, expectedDirectoryURL: url)
     }
     
     func testReplacingExistingStoredItemInCaches() {
         let cache = UserCache(rootDirectory: .caches, subdirectoryName: "users")
         self.validateReplacingItem(cache: cache)
+        self.validateReplacingArray(cache: cache)
     }
     
     func testReplacingExistingStoredItemInDocuments() {
         let cache = UserCache(rootDirectory: .documents, subdirectoryName: "users")
         self.validateReplacingItem(cache: cache)
+        self.validateReplacingArray(cache: cache)
     }
     
     func testCallingBackOnNonMainQueue() {


### PR DESCRIPTION
Realized that for a couple things I'm using this for, and particularly for `DataConvertibleCodable` objects, I'd really like to be able to cache an array of items. This opened a bit of a rabbit hole but now: 

- `Array` has new public extensions for both `DataConvertible` and `DataConvertibleCodable` which allow you to mash data into one big blob and get arrays back out. 
- `FilesystemDataCache` now includes the ability to cache and fetch those arrays (deleting works the same as with a single item)
- Tests have been updated to ensure arrays are doing what we need them to do
